### PR TITLE
Add cacert support for CSPO and CAPO

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@ This chart can be used to create a new namespace and two secrets for the cluster
 ```
 helm upgrade -i <tenant>-credentials -n <tenant> --create-namespace https://github.com/SovereignCloudStack/openstack-csp-helper/releases/latest/download/openstack-csp-helper.tgz -f clouds.yaml
 ```
+
+If OpenStack API is protected by the certificate issued by custom CA, add `--set cacert="$(cat /path/to/cacert)"` to the helm command.

--- a/templates/cloud-secret.yaml
+++ b/templates/cloud-secret.yaml
@@ -1,8 +1,11 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "cloud_name" . }} 
+  name: {{ include "cloud_name" . }}
 data:
   cloudName: {{ include "cloud_name" . | b64enc }}
   clouds.yaml: {{ toYaml .Values | b64enc }}
+  {{- if .Values.cacert }}
+  cacert: {{ .Values.cacert | b64enc }}
+  {{- end }}
 type: Opaque


### PR DESCRIPTION
Helm `.Files` object cannot be used for files external to the chart

Fixes #5 